### PR TITLE
enable passing an array of files in the files.src key

### DIFF
--- a/tasks/cache_breaker.js
+++ b/tasks/cache_breaker.js
@@ -181,6 +181,11 @@ module.exports = function(grunt) {
 //    Pull request submitted to Grunt to allow source-only file arrays
     if ( this.files ) {
       return this.files.forEach(function(f) {
+        if( f.src instanceof Array ) {
+          return f.src.forEach(function(fv) {
+            return processFile( fv, f.dest,  options );
+          });
+        }
         return processFile( f.src[0], f.dest,  options );
       });
     }


### PR DESCRIPTION
This format was not working for me, this pull request fixes:

```
cachebreaker : {
    css : {
      asset_url : '/asset/url.min.js',
      files : {
        src : ['path/1.php', 'path/1.html']
      }
    },
  }
```
